### PR TITLE
Install the exported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,3 +141,12 @@ set(CPACK_DEBIAN_PACKAGE_CONFLICTS "genicam, rcgcapi")
 set(CPACK_DEBIAN_PACKAGE_REPLACES "rcgcapi")
 
 include(cmake/package_debian.cmake)
+
+set(INSTALL_CMAKE_DIR "share/cmake/${PROJECT_NAME}")
+install(
+    EXPORT PROJECTTargets
+    FILE "${PROJECT_NAME_UPPER}Targets.cmake"
+    #this is the target folder of RC_GENICAM_APIConfig.cmake
+    DESTINATION lib/rc_genicam_api
+)
+


### PR DESCRIPTION
this helps to use the installed project via cmake.

the following files will additionally be installed:

> /usr/local/lib/rc_genicam_api/RC_GENICAM_APITargets.cmake
> /usr/local/lib/rc_genicam_api/RC_GENICAM_APITargets-relwithdebinfo.cmake

Where relwithdebinfo will be replaced with the used `CMAKE_BUILD_TYPE`