### PR TITLE
CMake full modern IMPORTED architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,6 @@ include(cmake/project_version.cmake)
 enable_testing()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/genicam/library/CPP/include)
 
 # - Configuration for code optimization -
 
@@ -48,48 +47,48 @@ if (NOT CMAKE_BUILD_TYPE)
 endif ()
 
 # - Standard definitions -
-
-add_definitions(-Wall)
+set(rc_genicam_api_COMPILE_CXX_OPTIONS)
+list(APPEND rc_genicam_api_COMPILE_CXX_OPTIONS -Wall)
 if (CMAKE_MAJOR_VERSION VERSION_LESS "3.1.0")
-  add_definitions(-std=c++11)
+list(APPEND rc_genicam_api_COMPILE_CXX_OPTIONS -std=c++11)
 else ()
   set(CMAKE_CXX_STANDARD 11)
 endif ()
 
 if (CMAKE_COMPILER_IS_GNUCC)
-  add_definitions(-Wno-unknown-pragmas)
+  list(APPEND rc_genicam_api_COMPILE_CXX_OPTIONS -Wno-unknown-pragmas)
 endif ()
 
 # In case of Visual Studio, enable exporting all symbols and disable some
 # warnings
 
 if (WIN32)
-  add_definitions(/DGENICAM_NO_AUTO_IMPLIB)
+  list(APPEND rc_genicam_api_COMPILE_CXX_OPTIONS /DGENICAM_NO_AUTO_IMPLIB)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 endif ()
 
 if (MSVC)
-  add_definitions("/wd4003")
-  add_definitions("/wd4514")
-  add_definitions("/wd4710")
-  add_definitions("/wd4820")
-  add_definitions("/wd4435")
-  add_definitions("/wd4668")
-  add_definitions("/wd4127")
-  add_definitions("/wd4265")
-  add_definitions("/wd4996")
-  add_definitions("/wd4437")
-  add_definitions("/wd4571")
-  add_definitions("/wd4355")
-  add_definitions("/wd4061")
-  add_definitions("/wd4800")
-  add_definitions("/wd4711")
-  add_definitions("/wd4774")
-  add_definitions("/wd4625")
-  add_definitions("/wd4626")
-  add_definitions("/wd5026")
-  add_definitions("/wd5027")
-  add_definitions("/wd5039")
+  list(APPEND rc_genicam_api_COMPILE_CXX_OPTIONS "/wd4003" 
+  "/wd4514" 
+  "/wd4710"
+  "/wd4820"
+  "/wd4435"
+  "/wd4668"
+  "/wd4127"
+  "/wd4265"
+  "/wd4996"
+  "/wd4437"
+  "/wd4571"
+  "/wd4355"
+  "/wd4061"
+  "/wd4800"
+  "/wd4711"
+  "/wd4774"
+  "/wd4625"
+  "/wd4626"
+  "/wd5026"
+  "/wd5027"
+  "/wd5039")
 endif ()
 
 # - Options -
@@ -100,11 +99,9 @@ option(BUILD_SHARED_LIBS "Build shared libs" ON)
 option(INSTALL_COMPLETION "Install bash completion" OFF)
 
 # - Build individual parts -
-
+find_package(Genicam REQUIRED NO_CMAKE_PATH PATHS ${CMAKE_CURRENT_SOURCE_DIR}/genicam CONFIG NO_DEFAULT_PATH)
 add_subdirectory(baumer)
 add_subdirectory(genicam)
-
-link_directories(${GENICAM_LIBRARIES_DIR})
 
 add_subdirectory(rc_genicam_api)
 if (BUILD_TOOLS)

--- a/cmake/PROJECTConfig.cmake.in
+++ b/cmake/PROJECTConfig.cmake.in
@@ -8,10 +8,67 @@
 # @PROJECT_NAME_UPPER@_STATIC_LIBRARIES - all static libraries
 
 get_filename_component(PROJECT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+get_filename_component(Genicam_IMPORT_PREFIX "${PROJECT_CMAKE_DIR}/../.." ABSOLUTE)
 
-set(@PROJECT_NAME_UPPER@_INCLUDE_DIRS "${PROJECT_CMAKE_DIR}/../../include")
-set(@PROJECT_NAME_UPPER@_LIBRARY_DIRS "${PROJECT_CMAKE_DIR}/..")
+### Resolve Genicam first 
+if (UNIX)
+  # try to get architecture from compiler
+  EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpmachine COMMAND tr -d '\n' OUTPUT_VARIABLE CXX_MACHINE)
+  string(REGEX REPLACE "([a-zA-Z_0-9]+).*" "\\1" ARCHITECTURE ${CXX_MACHINE})
+elseif (WIN32)
+  if ("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+    set(ARCHITECTURE WIN32_i86)
+  else ()
+    set(ARCHITECTURE WIN64_x64)
+  endif ()
+endif ()
 
+message(STATUS "Detected architecture ${ARCHITECTURE}")
+
+set(GENICAM_LIB_SUFFIX)
+if ("${ARCHITECTURE}" STREQUAL "arm")
+  set(GENICAM_LIB_SUFFIX ".so")
+elseif ("${ARCHITECTURE}" STREQUAL "aarch64")
+  set(GENICAM_LIB_SUFFIX ".so")
+elseif ("${ARCHITECTURE}" STREQUAL "i686")
+  set(GENICAM_LIB_SUFFIX ".so")
+elseif ("${ARCHITECTURE}" STREQUAL "x86_64")
+  set(GENICAM_LIB_SUFFIX ".so")
+elseif ("${ARCHITECTURE}" STREQUAL "WIN32_i86")
+  set(GENICAM_LIB_SUFFIX ".lib")
+elseif ("${ARCHITECTURE}" STREQUAL "WIN64_x64")
+  set(GENICAM_LIB_SUFFIX ".lib")
+else ()
+  message(FATAL_ERROR "Unknown architecture")
+endif ()
+
+foreach(GENICAM_LIB @Genicam_LIBRARIES@)
+  add_library(${GENICAM_LIB} SHARED IMPORTED)
+  set_property(TARGET ${GENICAM_LIB} APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+  set_property(TARGET ${GENICAM_LIB} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+  
+  string(REPLACE "Genicam::" "" GENICAM_LIB_NAME ${GENICAM_LIB})
+  set(GENICAM_LIB_FILE "${Genicam_IMPORT_PREFIX}/lib/${GENICAM_LIB_NAME}${GENICAM_LIB_SUFFIX}")
+  if (UNIX)
+	  set_target_properties(${GENICAM_LIB}
+	      PROPERTIES
+			  INTERFACE_INCLUDE_DIRECTORIES "${Genicam_IMPORT_PREFIX}/include/rc_genicam_api/genicam"
+		      IMPORTED_LOCATION_DEBUG "${GENICAM_LIB_FILE}"
+		      IMPORTED_LOCATION_RELEASE "${GENICAM_LIB_FILE}"
+		      IMPORTED_LOCATION "${GENICAM_LIB_FILE}"
+	  )
+  elseif (WIN32)
+	  set_target_properties(${GENICAM_LIB}
+	      PROPERTIES
+			  INTERFACE_INCLUDE_DIRECTORIES "${Genicam_IMPORT_PREFIX}/include/rc_genicam_api/genicam"
+		      IMPORTED_IMPLIB_DEBUG  "${GENICAM_LIB_FILE}"
+		      IMPORTED_IMPLIB_RELEASE "${GENICAM_LIB_FILE}"
+		      IMPORTED_IMPLIB "${GENICAM_LIB_FILE}"
+	  )
+  endif ()
+endforeach()
+
+## Targets
 include("${PROJECT_CMAKE_DIR}/@PROJECT_NAME_UPPER@Targets.cmake")
 
 set(@PROJECT_NAME_UPPER@_STATIC_LIBRARIES @PROJECT_STATIC_LIBRARIES@)

--- a/genicam/CMakeLists.txt
+++ b/genicam/CMakeLists.txt
@@ -14,50 +14,56 @@ endif ()
 
 message(STATUS "Detected architecture ${ARCHITECTURE}")
 
+set(GENICAM_LIB_SUFFIX)
+
 if ("${ARCHITECTURE}" STREQUAL "arm")
   set(GENICAM_LIBRARIES
-    libGCBase_gcc46_v3_1.so
-    libMathParser_gcc46_v3_1.so
-    libGenApi_gcc46_v3_1.so
-    libNodeMapData_gcc46_v3_1.so
-    liblog4cpp_gcc46_v3_1.so
-    libXmlParser_gcc46_v3_1.so
-    libLog_gcc46_v3_1.so
+    libGCBase_gcc46_v3_1
+    libMathParser_gcc46_v3_1
+    libGenApi_gcc46_v3_1
+    libNodeMapData_gcc46_v3_1
+    liblog4cpp_gcc46_v3_1
+    libXmlParser_gcc46_v3_1
+    libLog_gcc46_v3_1
   )
   set(GENICAM_LIBRARIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin/Linux32_ARMhf)
+  set(GENICAM_LIB_SUFFIX ".so")
 elseif ("${ARCHITECTURE}" STREQUAL "aarch64")
   set(GENICAM_LIBRARIES
-    libGCBase_gcc48_v3_1.so
-    libMathParser_gcc48_v3_1.so
-    libGenApi_gcc48_v3_1.so
-    libNodeMapData_gcc48_v3_1.so
-    liblog4cpp_gcc48_v3_1.so
-    libXmlParser_gcc48_v3_1.so
-    libLog_gcc48_v3_1.so
+    libGCBase_gcc48_v3_1
+    libMathParser_gcc48_v3_1
+    libGenApi_gcc48_v3_1
+    libNodeMapData_gcc48_v3_1
+    liblog4cpp_gcc48_v3_1
+    libXmlParser_gcc48_v3_1
+    libLog_gcc48_v3_1
   )
   set(GENICAM_LIBRARIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin/Linux64_ARM)
+  set(GENICAM_LIB_SUFFIX ".so")
 elseif ("${ARCHITECTURE}" STREQUAL "i686")
   set(GENICAM_LIBRARIES
-    libGCBase_gcc42_v3_1.so
-    libMathParser_gcc42_v3_1.so
-    libGenApi_gcc42_v3_1.so
-    libNodeMapData_gcc42_v3_1.so
-    liblog4cpp_gcc42_v3_1.so
-    libXmlParser_gcc42_v3_1.so
-    libLog_gcc42_v3_1.so
+    libGCBase_gcc42_v3_1
+    libMathParser_gcc42_v3_1
+    libGenApi_gcc42_v3_1
+    libNodeMapData_gcc42_v3_1
+    liblog4cpp_gcc42_v3_1
+    libXmlParser_gcc42_v3_1
+    libLog_gcc42_v3_1
   )
   set(GENICAM_LIBRARIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin/Linux32_i86)
+  set(GENICAM_LIB_SUFFIX ".so")
 elseif ("${ARCHITECTURE}" STREQUAL "x86_64")
   set(GENICAM_LIBRARIES
-    libGCBase_gcc42_v3_1.so
-    libMathParser_gcc42_v3_1.so
-    libGenApi_gcc42_v3_1.so
-    libNodeMapData_gcc42_v3_1.so
-    liblog4cpp_gcc42_v3_1.so
-    libXmlParser_gcc42_v3_1.so
-    libLog_gcc42_v3_1.so
+    libGCBase_gcc42_v3_1
+    libMathParser_gcc42_v3_1
+    libGenApi_gcc42_v3_1
+    libNodeMapData_gcc42_v3_1
+    liblog4cpp_gcc42_v3_1
+    libXmlParser_gcc42_v3_1
+    libLog_gcc42_v3_1
   )
   set(GENICAM_LIBRARIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/bin/Linux64_x64)
+  set(GENICAM_LIB_SUFFIX ".so")
 elseif ("${ARCHITECTURE}" STREQUAL "WIN32_i86")
   install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/bin/Win32_i86/GCBase_MD_VC120_v3_1.dll
@@ -71,10 +77,11 @@ elseif ("${ARCHITECTURE}" STREQUAL "WIN32_i86")
 	COMPONENT bin DESTINATION bin
   )
   set(GENICAM_LIBRARIES
-    GCBase_MD_VC120_v3_1.lib
-    GenApi_MD_VC120_v3_1.lib
+    GCBase_MD_VC120_v3_1
+    GenApi_MD_VC120_v3_1
   )
   set(GENICAM_LIBRARIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/library/CPP/lib/Win32_i86)
+  set(GENICAM_LIB_SUFFIX ".lib")
 elseif ("${ARCHITECTURE}" STREQUAL "WIN64_x64")
   install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/bin/Win64_x64/GCBase_MD_VC120_v3_1.dll
@@ -88,28 +95,24 @@ elseif ("${ARCHITECTURE}" STREQUAL "WIN64_x64")
 	COMPONENT bin DESTINATION bin
   )
   set(GENICAM_LIBRARIES
-    GCBase_MD_VC120_v3_1.lib
-    GenApi_MD_VC120_v3_1.lib
+    GCBase_MD_VC120_v3_1
+    GenApi_MD_VC120_v3_1
   )
   set(GENICAM_LIBRARIES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/library/CPP/lib/Win64_x64)
+  set(GENICAM_LIB_SUFFIX ".lib")
 else ()
   message(FATAL_ERROR "Unknown architecture")
 endif ()
 
-function(PREPEND var prefix)
-  set(listVar "")
-  foreach(f ${ARGN})
-    list(APPEND listVar "${prefix}/${f}")
-  endforeach(f)
-  set(${var} "${listVar}" PARENT_SCOPE)
-endfunction(PREPEND)
-
-prepend(FILES_TO_INSTALL ${GENICAM_LIBRARIES_DIR} ${GENICAM_LIBRARIES})
+set(FILES_TO_INSTALL)
+foreach(GENICAM_LIB ${GENICAM_LIBRARIES})
+  set(GENICAM_LIB_FILE "${GENICAM_LIBRARIES_DIR}/${GENICAM_LIB}${GENICAM_LIB_SUFFIX}")
+  list(APPEND FILES_TO_INSTALL "${GENICAM_LIB_FILE}")
+endforeach()
 
 install(FILES ${FILES_TO_INSTALL} COMPONENT bin DESTINATION lib)
 
-set(GENICAM_LIBRARIES ${GENICAM_LIBRARIES} PARENT_SCOPE)
-set(GENICAM_LIBRARIES_DIR ${GENICAM_LIBRARIES_DIR} PARENT_SCOPE)
+set(GENICAM_LIBRARIES ${GENICAM_NAMESPACE_LIBS})
 
 # only install headers if we build and install the shared lib
 if (BUILD_SHARED_LIBS)

--- a/genicam/GenicamConfig.cmake
+++ b/genicam/GenicamConfig.cmake
@@ -1,0 +1,144 @@
+# Config file for Genicam
+#
+# It defines the requires genicam libraries as imported targets and defines:
+# - Genicam_LIBRARIES: list of all imported target with their prefix
+
+get_filename_component(PACKAGE_PREFIX_DIR "${CMAKE_CURRENT_LIST_DIR}/" ABSOLUTE)
+
+if (UNIX)
+  # try to get architecture from compiler
+  EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpmachine COMMAND tr -d '\n' OUTPUT_VARIABLE CXX_MACHINE)
+  string(REGEX REPLACE "([a-zA-Z_0-9]+).*" "\\1" ARCHITECTURE ${CXX_MACHINE})
+elseif (WIN32)
+  if ("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4")
+    set(ARCHITECTURE WIN32_i86)
+  else ()
+    set(ARCHITECTURE WIN64_x64)
+  endif ()
+endif ()
+
+message(STATUS "Detected architecture ${ARCHITECTURE}")
+
+set(GENICAM_LIB_SUFFIX)
+
+if ("${ARCHITECTURE}" STREQUAL "arm")
+  set(GENICAM_LIBRARIES
+    libGCBase_gcc46_v3_1
+    libMathParser_gcc46_v3_1
+    libGenApi_gcc46_v3_1
+    libNodeMapData_gcc46_v3_1
+    liblog4cpp_gcc46_v3_1
+    libXmlParser_gcc46_v3_1
+    libLog_gcc46_v3_1
+  )
+  set(GENICAM_LIBRARIES_DIR ${PACKAGE_PREFIX_DIR}/bin/Linux32_ARMhf)
+  set(GENICAM_LIB_SUFFIX ".so")
+elseif ("${ARCHITECTURE}" STREQUAL "aarch64")
+  set(GENICAM_LIBRARIES
+    libGCBase_gcc48_v3_1
+    libMathParser_gcc48_v3_1
+    libGenApi_gcc48_v3_1
+    libNodeMapData_gcc48_v3_1
+    liblog4cpp_gcc48_v3_1
+    libXmlParser_gcc48_v3_1
+    libLog_gcc48_v3_1
+  )
+  set(GENICAM_LIBRARIES_DIR ${PACKAGE_PREFIX_DIR}/bin/Linux64_ARM)
+  set(GENICAM_LIB_SUFFIX ".so")
+elseif ("${ARCHITECTURE}" STREQUAL "i686")
+  set(GENICAM_LIBRARIES
+    libGCBase_gcc42_v3_1
+    libMathParser_gcc42_v3_1
+    libGenApi_gcc42_v3_1
+    libNodeMapData_gcc42_v3_1
+    liblog4cpp_gcc42_v3_1
+    libXmlParser_gcc42_v3_1
+    libLog_gcc42_v3_1
+  )
+  set(GENICAM_LIBRARIES_DIR ${PACKAGE_PREFIX_DIR}/bin/Linux32_i86)
+  set(GENICAM_LIB_SUFFIX ".so")
+elseif ("${ARCHITECTURE}" STREQUAL "x86_64")
+  set(GENICAM_LIBRARIES
+    libGCBase_gcc42_v3_1
+    libMathParser_gcc42_v3_1
+    libGenApi_gcc42_v3_1
+    libNodeMapData_gcc42_v3_1
+    liblog4cpp_gcc42_v3_1
+    libXmlParser_gcc42_v3_1
+    libLog_gcc42_v3_1
+  )
+  set(GENICAM_LIBRARIES_DIR ${PACKAGE_PREFIX_DIR}/bin/Linux64_x64)
+  set(GENICAM_LIB_SUFFIX ".so")
+elseif ("${ARCHITECTURE}" STREQUAL "WIN32_i86")
+  install(FILES
+    ${PACKAGE_PREFIX_DIR}/bin/Win32_i86/GCBase_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win32_i86/GenApi_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win32_i86/Log_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win32_i86/MathParser_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win32_i86/msvcp120.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win32_i86/msvcr120.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win32_i86/NodeMapData_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win32_i86/XmlParser_MD_VC120_v3_1.dll
+	COMPONENT bin DESTINATION bin
+  )
+  set(GENICAM_LIBRARIES
+    GCBase_MD_VC120_v3_1
+    GenApi_MD_VC120_v3_1
+  )
+  set(GENICAM_LIBRARIES_DIR ${PACKAGE_PREFIX_DIR}/library/CPP/lib/Win32_i86)
+  set(GENICAM_LIB_SUFFIX ".lib")
+elseif ("${ARCHITECTURE}" STREQUAL "WIN64_x64")
+  install(FILES
+    ${PACKAGE_PREFIX_DIR}/bin/Win64_x64/GCBase_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win64_x64/GenApi_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win64_x64/Log_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win64_x64/MathParser_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win64_x64/msvcp120.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win64_x64/msvcr120.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win64_x64/NodeMapData_MD_VC120_v3_1.dll
+    ${PACKAGE_PREFIX_DIR}/bin/Win64_x64/XmlParser_MD_VC120_v3_1.dll
+	COMPONENT bin DESTINATION bin
+  )
+  set(GENICAM_LIBRARIES
+    GCBase_MD_VC120_v3_1
+    GenApi_MD_VC120_v3_1
+  )
+  set(GENICAM_LIBRARIES_DIR ${PACKAGE_PREFIX_DIR}/library/CPP/lib/Win64_x64)
+  set(GENICAM_LIB_SUFFIX ".lib")
+else ()
+  message(FATAL_ERROR "Unknown architecture")
+endif ()
+
+set(GENICAM_NAMESPACE_LIBS)
+foreach(GENICAM_LIB ${GENICAM_LIBRARIES})
+  set(GENICAM_NAMESPACE_LIB "Genicam::${GENICAM_LIB}")
+  list(APPEND GENICAM_NAMESPACE_LIBS ${GENICAM_NAMESPACE_LIB})
+  add_library(${GENICAM_NAMESPACE_LIB} SHARED IMPORTED)
+  message(STATUS "Adding imported: ${GENICAM_NAMESPACE_LIB}")
+  set_property(TARGET ${GENICAM_NAMESPACE_LIB} APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+  set_property(TARGET ${GENICAM_NAMESPACE_LIB} APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+  
+  set(GENICAM_LIB_FILE "${GENICAM_LIBRARIES_DIR}/${GENICAM_LIB}${GENICAM_LIB_SUFFIX}")
+  if (UNIX)
+	  set_target_properties(${GENICAM_NAMESPACE_LIB}
+	      PROPERTIES
+			  INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/library/CPP/include/"
+		      IMPORTED_LOCATION_DEBUG "${GENICAM_LIB_FILE}"
+		      IMPORTED_LOCATION_RELEASE "${GENICAM_LIB_FILE}"
+		      IMPORTED_LOCATION "${GENICAM_LIB_FILE}"
+	  )
+  elseif (WIN32)
+	  set_target_properties(${GENICAM_NAMESPACE_LIB}
+	      PROPERTIES
+			  INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/library/CPP/include/"
+		      IMPORTED_IMPLIB_DEBUG  "${GENICAM_LIB_FILE}"
+		      IMPORTED_IMPLIB_RELEASE "${GENICAM_LIB_FILE}"
+		      IMPORTED_IMPLIB "${GENICAM_LIB_FILE}"
+	  )
+  endif ()
+endforeach()
+
+
+set(Genicam_LIBRARIES ${GENICAM_NAMESPACE_LIBS} CACHE STRING "Genicam targets with namespace")
+set(Genicam_FOUND ON CACHE BOOL "")
+set(PACKAGE_PREFIX_DIR)

--- a/rc_genicam_api/CMakeLists.txt
+++ b/rc_genicam_api/CMakeLists.txt
@@ -76,7 +76,8 @@ elseif (WIN32)
 endif ()
 
 add_library(rc_genicam_api_static STATIC ${src})
-target_link_libraries(rc_genicam_api_static ${GENICAM_LIBRARIES})
+target_link_libraries(rc_genicam_api_static ${Genicam_LIBRARIES})
+target_compile_options(rc_genicam_api_static PUBLIC ${rc_genicam_api_COMPILE_CXX_OPTIONS})
 if (UNIX)
   target_link_libraries(rc_genicam_api_static dl)
 endif ()
@@ -85,8 +86,8 @@ endif ()
 
 if (BUILD_SHARED_LIBS)
   add_library(rc_genicam_api SHARED ${src})
-  target_link_libraries(rc_genicam_api ${GENICAM_LIBRARIES})
-
+  target_link_libraries(rc_genicam_api ${Genicam_LIBRARIES})
+  target_compile_options(rc_genicam_api PUBLIC ${rc_genicam_api_COMPILE_CXX_OPTIONS})
   if (UNIX)
     target_link_libraries(rc_genicam_api dl)
   endif ()
@@ -96,7 +97,8 @@ if (BUILD_SHARED_LIBS)
   install(TARGETS rc_genicam_api EXPORT PROJECTTargets COMPONENT bin
           RUNTIME DESTINATION bin
 		  LIBRARY DESTINATION lib
-		  ARCHIVE DESTINATION lib)
+		  ARCHIVE DESTINATION lib
+		  INCLUDES DESTINATION include)
 endif ()
 
 # only install headers if we build and install the shared lib


### PR DESCRIPTION
In the current implementation, compilation definition are not stored in the target. Additionally, Genicam dependencies are stored as a library filename that requires the use of a global `link_directories` which complicates the use of the library in dependent projects. Similarly, the includes were not stored in the installed target, therefore, the dependent projects also had to use the global `include_directories`. 

In the proposed implementation, one can simple use `target_link_library(myTarget PUBLIC rc_genicam_api)` and all includes, definitions and dependent libraries and their compilation and includes are passed automatically. 