### PR TITLE
show enum options even if WriteOnly

### DIFF
--- a/tools/gc_info.cc
+++ b/tools/gc_info.cc
@@ -252,7 +252,7 @@ void printNode(const std::string &prefix, GenApi::INode *node, int depth)
 
           GenApi::IEnumeration *p=dynamic_cast<GenApi::IEnumeration *>(node);
 
-          if (GenApi::IsReadable(p))
+          if (p != nullptr)
           {
             std::cout << '[';
 
@@ -271,7 +271,7 @@ void printNode(const std::string &prefix, GenApi::INode *node, int depth)
 
             std::cout << "]: ";
 
-            if (p->GetCurrentEntry() != 0)
+            if (GenApi::IsReadable(p->GetAccessMode()) && p->GetCurrentEntry() != 0)
             {
               std::cout << p->GetCurrentEntry()->GetSymbolic();
             }


### PR DESCRIPTION
Previously:

- If the node type is GenApi::intfIEnumeration but the accessMode is WriteOnly, the enum options will not be displayed.

Now:

- User able to view the available options for GenApi::intfIEnumeration even if the feature node is WriteOnly.